### PR TITLE
Select language only via cookie instead of additional url suffix

### DIFF
--- a/project/flaskr/app.py
+++ b/project/flaskr/app.py
@@ -45,15 +45,14 @@ def create_app():
         return render_template("app/language.html")
         pass
 
-    @app.route("/crossing_<language>")
-    def border_selection(language):
+    @app.route("/crossing")
+    def border_selection():
         """
         Page for which border to cross
-        Args:
-           language: the chosen language
         Returns: HTML Page
 
         """
+        language = request.cookies.get('language')
         return render_template("app/crossing.html", localization=LOCAL_MAP[language])
 
     @app.route('/answer')

--- a/project/flaskr/routes/questionaire.py
+++ b/project/flaskr/routes/questionaire.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, request
 from project.flaskr import static_folder, template_folder
 
 
@@ -14,8 +14,9 @@ def get_questionaire_blueprint(questionaire, json_schema, local_map):
 
     """
     questionnair = Blueprint('questionnair', __name__, template_folder=template_folder, static_folder=static_folder)
-    @questionnair.route("/questionnair_<language>")
-    def questionnaire_begin(language):
+    @questionnair.route("/questionnair")
+    def questionnaire_begin():
+        language = request.cookies.get('language')
         localized_questions = questionaire.localized_questions(language)
 
         return render_template("questionnair/page.html", questions=localized_questions, json_schema=json_schema, localization=local_map[language])

--- a/project/flaskr/static/js/data_processing.js
+++ b/project/flaskr/static/js/data_processing.js
@@ -137,8 +137,7 @@ function write_answers(answers, questionaire) {
         var question = document.getElementById("view_answer_" + list[i].question_id);
         if (question) {
             var ans_elem = question.getElementsByClassName("answer")[0];
-            // FIXME use selected language
-            var text = localized_answer(list[i], questionaire, "german");
+            var text = localized_answer(list[i], questionaire, getCookie('language'));
             var text_elem = document.createTextNode(text.answer_text);
             if (ans_elem) {
                 removeAllChildren(ans_elem);

--- a/project/flaskr/templates/app/crossing.html
+++ b/project/flaskr/templates/app/crossing.html
@@ -39,7 +39,7 @@
             </div>
 
             <div class="form-inline">
-                <button id="nextButton" onclick="location.href='questionnair_' + getCookie('language') + '?' + getLanguageURLAppendix();"><i class="fas fa-arrow-right"></i></button>
+                <button id="nextButton" onclick="location.href='questionnair?' + getLanguageURLAppendix();"><i class="fas fa-arrow-right"></i></button>
             </div>
         </nav>
     </div>

--- a/project/flaskr/templates/app/language.html
+++ b/project/flaskr/templates/app/language.html
@@ -28,7 +28,7 @@
             </div>
 
             <div class="form-inline">
-                <button id="nextButton" onclick="location.href='crossing_' + getCookie('language')"><i class="fas fa-arrow-right"></i></button>
+                <button id="nextButton" onclick="location.href='crossing'"><i class="fas fa-arrow-right"></i></button>
             </div>
         </nav>
 

--- a/project/flaskr/templates/questionnair/page.html
+++ b/project/flaskr/templates/questionnair/page.html
@@ -126,7 +126,7 @@
      document.getElementById('flag2').setAttribute('data', 'static/flags/' + to_language + '.svg')
 
      function backToCrossing() {
-         location.href = 'crossing_' + getCookie('language') + '?from=' + from_language + '&to=' + to_language
+         location.href = 'crossing?from=' + from_language + '&to=' + to_language
      }
 
      const questionaire_json = `{{json_schema}}`


### PR DESCRIPTION
Border control gets the answers in the prefered (preselected) language.
Switching the language (in an other tab) and reload page will change
language now.